### PR TITLE
Fix Docker build failure and update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Build Stage
-FROM golang:1.24.3 as builder
+FROM golang:1.24.3 AS builder
 
 WORKDIR /app
 
 COPY go.mod go.sum ./
+COPY api/proto/ ./api/proto/
 RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app ./cmd/app
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app ./cmd/server
 
 # Run Stage
 FROM alpine:latest


### PR DESCRIPTION
This commit addresses issues in the Dockerfile:

1.  Resolves `go mod download` failure:
    - The `api/proto/` directory, which contains a local module referenced by a `replace` directive in the main `go.mod`, is now copied before `RUN go mod download`. This ensures `api/proto/go.mod` is available, preventing the "no such file or directory" error.

2.  Corrects Go build path:
    - The `go build` command now targets `./cmd/server` instead of the incorrect `./cmd/app`.

3.  Fixes Dockerfile linting warning:
    - Changed `as builder` to `AS builder` in the `FROM` instruction for consistent keyword casing.